### PR TITLE
Fixed modal bug

### DIFF
--- a/client/public/app/dashboard/dashboard-controller.js
+++ b/client/public/app/dashboard/dashboard-controller.js
@@ -33,6 +33,7 @@ angular.module('wtf.dashboard', ['checklist-model'])
     // }, true);
     
     $scope.getShoppingList = function() {
+      $("#shopCheck").closeModal();
       $location.path('shopping-list');
     };
 


### PR DESCRIPTION
I think this should work. I think what was happening was that on ng-click, getShoppingList was called, and changed the path to the shopping-list.html file. Sometimes, this would happen faster than the "modal-close" class would get triggered. So I had the getShoppingList function call the modal close function before it redirects, to make sure it's always closed. It seems to work, but further testing can show if this is still an issue. Might want to see if this bug occurs elsewhere and solve it the same way. Until then, close #59 
