### PR TITLE
Truncate all price displays to 2 decimal places

### DIFF
--- a/client/app/recipes/recipes.html
+++ b/client/app/recipes/recipes.html
@@ -52,7 +52,7 @@
         </div>
         <div class="card-content">
           <span class="card-title activator grey-text text-darken-4" for="{{item}}">{{item.title}}</span>
-          <span class="price">${{item.price}}</span>
+          <span class="price">${{item.price.toFixed(2)}}</span>
           </br>
           <input type="checkbox" checklist-model="recipes.selected" checklist-value ="item" id="{{item}}" />
           <label class="left" for="{{item}}">I'm eating this</label> </br></br></br>
@@ -63,7 +63,7 @@
         </div>
         <div class="card-reveal">
           <span class="card-title grey-text text-darken-4" for="{{item}}">{{item.title}}<i class="material-icons right">close</i></span>
-          <span class="price left">${{item.price}}</span></br> </br>
+          <span class="price left">${{item.price.toFixed(2)}}</span></br> </br>
           <div ng-repeat="subitem in item.ingredients">
             <span>{{subitem}}</span>
           </div>

--- a/client/app/saved-lists/saved-lists.html
+++ b/client/app/saved-lists/saved-lists.html
@@ -29,7 +29,7 @@
       <span class="secondary-content">Price: ${{props[1]}}</span>
     </li>
     <li class="collection-item center-align list-price">
-      Total Price: ${{list.totalPrice}}
+      Total Price: ${{list.totalPrice.toFixed(2)}}
     </li>
     <div class="center-align"><button class="btn waves-effect waves-light" ng-click="shop(list)">Shop with this list</button></div>
   </ul>


### PR DESCRIPTION
There was a bug where sometimes a price would display as "$8.9200000000001" or something similar. This is some issue with JavaScript, sometimes it messes up with floating point numbers. I put a band-aid on the problem by only displaying two decimal places. The database will only store prices up to two decimal places (using SQL type numeric(8,2) ) so prices will never be saved incorrectly. I believe this issue is fully resolved with this fix.
