### PR TITLE
Remove unit of measure

### DIFF
--- a/client/app/fridge/fridge.html
+++ b/client/app/fridge/fridge.html
@@ -23,7 +23,6 @@
         <th>Ingredient</th>
         <th>Price</th>    
         <th>Quantity </th>
-        <th>Unit of Measure</th>
         <th>Expiration<th>
       </tr>
     </thead>


### PR DESCRIPTION
Closes #107 ?

I thought this was going to require changing the database, but apparently we didn't have a unit of measure field in any of the tables anyway.
