### PR TITLE
Enable users to create shopping lists without recipes

### DIFF
--- a/client/app/create-shopping-list/create-shopping-list.html
+++ b/client/app/create-shopping-list/create-shopping-list.html
@@ -2,11 +2,14 @@
   <div class="row center-align">
     Create Shopping List
     <br>
-    <button class="saveButton btn waves-effect waves-light" ng-click="saveModal()">Create shopping list</button>
+    <button class="saveButton btn waves-effect waves-light" ng-click="saveModal()">Save shopping list</button>
   </div>
   <div class="row center-align">
     <a ng-click='addModal()' class="btn-floating btn-medium waves-effect waves-light blue"><i class="material-icons">add</i></a>
     Add item
+  </div>
+  <div class="center-align" ng-show="errorFlag">
+    <span class="error">You must have at least one item on your shopping list in order to save it.</span>
   </div>
   <div ng-hide="notSavedFlag">
     Shopping list saved.

--- a/client/app/dashboard/dashboard.html
+++ b/client/app/dashboard/dashboard.html
@@ -134,7 +134,8 @@
           <p ng-hide="hideList"> Your cheapest list, {{leastExpensiveList.list_name || leastExpensiveList.date}}, costs ${{leastExpensiveList.totalPrice}}</p>
         </div>
         <div class="card-action">
-            <a href="#/saved-lists">See Saved Lists</a>
+            <a class="col s6" href="#/saved-lists">See Saved Lists</a>
+            <a href="#/create-list">Create New List</a>
         </div>
       </div>
     </div>

--- a/client/app/recipes/recipes.html
+++ b/client/app/recipes/recipes.html
@@ -109,7 +109,7 @@
 
 
   <!-- goShoppingButton -->
-  <div ng-show="recipes.selected.length > 0" class="fixed-action-btn" style="bottom: 45px; right: 24px;">
+  <div class="fixed-action-btn" style="bottom: 45px; right: 24px;">
     <a class="modal-trigger" href="#shopCheck"><i class="large material-icons">shopping_cart</i>
     </a>
   </div>
@@ -117,11 +117,12 @@
   <!-- shopCheck Modal -->
   <div id="shopCheck" class="modal">
     <div class="modal-content">
-      <p>On this trip, you are making:<p>
+      <p ng-show="recipes.selected.length > 0">On this trip, you are making:</p>
+      <p ng-hide="recipes.selected.length > 0">Do you want to create a shopping list without selecting recipes?</p>
       <ul>
         <li ng-repeat="recipe in recipes.selected">{{recipe.title}}</li>
       </ul>
-        Is this correct?
+      <p ng-show="recipes.selected.length > 0">Is this correct?</p>
     </div>
     <div class="modal-footer">
       <a class="modal-action modal-close waves-effect waves-green btn-flat">No</a>

--- a/client/app/saved-lists/saved-lists.html
+++ b/client/app/saved-lists/saved-lists.html
@@ -1,6 +1,8 @@
 <div class="container">
   <div class="row center-align">
     My Saved Shopping Lists
+    <br>
+    <a class="saveButton btn waves-effect waves-light" href="#/create-list">Create New List</a>
   </div>
 
   <div class="container" ng-if="show">

--- a/client/public/app/create-shopping-list/create-shopping-list-controller.js
+++ b/client/public/app/create-shopping-list/create-shopping-list-controller.js
@@ -2,6 +2,7 @@ angular.module('wtf.create-shopping-list', [])
   .controller('CreateShoppingListController', ["$scope", "$window", "$location", "Recipes", "SavedLists", function($scope, $window, $location, Recipes, SavedLists) {
 
     $scope.shoppingList = [];
+    $scope.errorFlag = false;
 
     $scope.addModal = function() {
       $("#addItem").openModal();
@@ -21,16 +22,21 @@ angular.module('wtf.create-shopping-list', [])
       }
       else {
         $scope.shoppingList.push({'name':$scope.itemToAdd, 'price':'0.00', 'qty':1});
+        $scope.errorFlag = false;
       }
     };
 
     $scope.saveModal = function() {
-      $("#saveList").openModal();
+      if($scope.shoppingList.length) {
+        $("#saveList").openModal();
+      }
+      else {
+        $scope.errorFlag = true;
+      }
     };
 
     $scope.populateList = function() {
-      // When we initialize this page, set fridgeFlag to true, enabling the fridge button.
-      // Also set notSavedFlag to true, enabling the save button
+      // Set notSavedFlag to true, enabling the save button
       $scope.notSavedFlag = true;
       $scope.totalPrice = 0;
 


### PR DESCRIPTION
This makes the shopping cart always visible on the recipes page, and if no recipes are selected it shows a different message to confirm. Also changed "Create shopping list" button to "Save shopping list", mainly because it's confusing, especially on a blank page. The shopping list is being created on the page, they need the button to save it. If they try to save a shopping list with no items, an error message shows.

Only one thing I'm wondering about - should there be maybe an extra link on the nav bar to take users straight to the create shopping list page? If they have no recipes at all, it might seem counter intuitive to have to click on recipes in order to go shopping.

Closes #177 
