### PR TITLE
Correct ingredient price index syntax.

### DIFF
--- a/server/shoppingLists/shoppingListsController.js
+++ b/server/shoppingLists/shoppingListsController.js
@@ -44,7 +44,7 @@ module.exports = function(ShoppingLists, Ingredients) {
               // check if Ingredient exists! if not, it needs to be added to ingredients table and
               // then added to the shopping_lists_ingredients table
               if (!ingredient.length) {
-                Ingredients.addIngredient(req.user.id, list[index].name, list[index.price])
+                Ingredients.addIngredient(req.user.id, list[index].name, list[index].price)
                   .then(function(ingredientId) {
                     ShoppingLists.newItem(listId, ingredientId[0], list[index].qty).then(function(){});
                   })


### PR DESCRIPTION
The price update function incase of new ingredients in shopping list had a syntax error which led to that value being undefined when console logged and zero in database. If the user was using the add to fridge button first, in that case the price logic over there added the price for the new ingredient and the bug wasn't visible. 
The price updating in general is still inconsistent as mentioned in another bug 208, which is still open.
